### PR TITLE
Feature/persist configuration

### DIFF
--- a/addon/globalPlugins/TimerForNVDA/__init__.py
+++ b/addon/globalPlugins/TimerForNVDA/__init__.py
@@ -5,7 +5,6 @@ from scriptHandler import script
 from .timer import getStatus, timer
 import ui
 import wx
-import versionInfo
 
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):

--- a/addon/globalPlugins/TimerForNVDA/conf.py
+++ b/addon/globalPlugins/TimerForNVDA/conf.py
@@ -5,7 +5,7 @@ ADDON_CONFIG = "timerForNVDA"
 
 def initConfiguration():
     confspec = {
-        "reportWithSound": "boolean( default=False)",
+        "reportWithSound": "boolean( default=True)",
         "reportWithSpeech": "boolean( default=False)",
         "operationMode": "string( default=TIMER)",
         "timeUnit": "string( default=SECONDS)",

--- a/addon/globalPlugins/TimerForNVDA/conf.py
+++ b/addon/globalPlugins/TimerForNVDA/conf.py
@@ -1,0 +1,26 @@
+import config
+
+ADDON_CONFIG = "timerForNVDA"
+
+
+def initConfiguration():
+    confspec = {
+        "reportWithSound": "boolean( default=False)",
+        "reportWithSpeech": "boolean( default=False)",
+        "operationMode": "string( default=TIMER)",
+        "timeUnit": "string( default=SECONDS)",
+    }
+
+    config.conf.spec[ADDON_CONFIG] = confspec
+
+
+def getConfig(key):
+    value = config.conf[ADDON_CONFIG][key]
+    return value
+
+
+def setConfig(key, value):
+    config.conf[ADDON_CONFIG][key] = value
+
+
+initConfiguration()

--- a/addon/globalPlugins/TimerForNVDA/timer.py
+++ b/addon/globalPlugins/TimerForNVDA/timer.py
@@ -5,7 +5,7 @@
 # See the file COPYING.txt for more details.
 
 
-import config
+from . import conf
 import core
 from logHandler import log
 import nvwave
@@ -19,6 +19,8 @@ import ui
 
 timerRunning = False
 
+timer = None
+
 
 class Timer:
 
@@ -28,8 +30,8 @@ class Timer:
         self._running = False
         self._shouldRun = False
         self._thread = None
-        self._mode = OperationMode.TIMER
-        self._timeUnit = TimeUnit.SECONDS
+        self._mode = OperationMode[conf.getConfig("operationMode")]
+        self._timeUnit = TimeUnit[conf.getConfig("timeUnit")]
         self._reporters = []
         self._counterLock = threading.Lock()
 
@@ -45,7 +47,7 @@ class Timer:
                 return
         self._reporters.append(func)
 
-    def unregisterReport(self, func):
+    def unregisterReporter(self, func):
         try:
             self._reporters.remove(func)
         except:
@@ -224,9 +226,16 @@ def reportMessages(evt):
         ui.message(f"{_('warning: ')} {evt['message']}")
 
 
-timer = Timer()
-timer.registerReporter(reportTimeCompletion)
-timer.registerReporter(reportMessages)
+def initializeTimer():
+    global timer
+    log.debug("enttrroooiouuuoiouo")
+    if not timer is None:
+        log.debug("saiiiuuuuaaauaiauaiaue")
+        return
+    timer = Timer()
+    timer.registerReporter(reportTimeCompletion)
+    timer.registerReporter(reportMessages)
+
 
 timePhases = {
     TimeUnit.SECONDS.name: 1,
@@ -234,6 +243,7 @@ timePhases = {
     TimeUnit.HOURS: 3
 }
 
+initializeTimer()
 
 def makeTime(currentTime, timeUnit):
     phases = timePhases[timeUnit.name]

--- a/addon/globalPlugins/TimerForNVDA/timer.py
+++ b/addon/globalPlugins/TimerForNVDA/timer.py
@@ -228,9 +228,7 @@ def reportMessages(evt):
 
 def initializeTimer():
     global timer
-    log.debug("enttrroooiouuuoiouo")
     if not timer is None:
-        log.debug("saiiiuuuuaaauaiauaiaue")
         return
     timer = Timer()
     timer.registerReporter(reportTimeCompletion)
@@ -244,6 +242,7 @@ timePhases = {
 }
 
 initializeTimer()
+
 
 def makeTime(currentTime, timeUnit):
     phases = timePhases[timeUnit.name]


### PR DESCRIPTION
In this PR we implement some minor changes om UI and also configuration persistence.

This allows the timer dialog to keep the current settings instead of resetting them to defaults, which was causing an inconsistent user experience.
This also allows current conffigurations, such as active reports, timee unit and operation mode to be retrieved among NVDA sessions.