### PR TITLE
Minimum version update to work NVDA-2022.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Timer for NVDA 1.4.0
+# Timer for NVDA 1.5.0
 Brings timer and stopwatch functionalities right to NVDA
 
 ## download
 
-Download the [ Simple Timer and stopwatch for NVDA 1.4.0 addon](https://github.com/marlon-sousa/TimerForNVDA/releases/download/1.4.0/TimerForNVDA-1.4.0.nvda-addon)
+Download the [ Simple Timer and stopwatch for NVDA 1.5.0 addon](https://github.com/marlon-sousa/TimerForNVDA/releases/download/1.5.0/TimerForNVDA-1.5.0.nvda-addon)
 
 ## timers and stopwatches
 
@@ -129,5 +129,4 @@ Special thanks to
 * Rémy Ruiz - French translation
 * Ângelo Miguel Abrantes - Portuguese translation
 * Rémy Ruiz - Spanish translation
-*Brian Missao da Vera - Minimum version update to work on NVDA-2022.1
-
+*Brian Missao da Vera - NVDA 2022.1 compatibility

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ If you want to contribute or translate this addon, please access the [project re
 
 ## Contributors
 
+*Brian Missao da Vera
+
 Special thanks to
 
 * Marlon Brandão de Sousa - Brazilian Portuguese translation

--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ If you want to contribute or translate this addon, please access the [project re
 
 ## Contributors
 
-*Brian Missao da Vera
-
 Special thanks to
 
 * Marlon Brandão de Sousa - Brazilian Portuguese translation
@@ -131,4 +129,5 @@ Special thanks to
 * Rémy Ruiz - French translation
 * Ângelo Miguel Abrantes - Portuguese translation
 * Rémy Ruiz - Spanish translation
+*Brian Missao da Vera - Minimum version update to work on NVDA-2022.1
 

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -129,4 +129,4 @@ Special thanks to
 * Rémy Ruiz - French translation
 * Ângelo Miguel Abrantes - Portuguese translation
 * Rémy Ruiz - Spanish translation
-*Brian Missao da Vera - Minimum version update to work on NVDA-2022.1
+*Brian Missao da Vera - NVDA 2022.1 compatibility

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -122,8 +122,6 @@ If you want to contribute or translate this addon, please access the [project re
 
 ## Contributors
 
-*Brian Missao da Vera
-
 Special thanks to
 
 * Marlon Brandão de Sousa - Brazilian Portuguese translation
@@ -131,4 +129,4 @@ Special thanks to
 * Rémy Ruiz - French translation
 * Ângelo Miguel Abrantes - Portuguese translation
 * Rémy Ruiz - Spanish translation
-
+*Brian Missao da Vera - Minimum version update to work on NVDA-2022.1

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -122,6 +122,8 @@ If you want to contribute or translate this addon, please access the [project re
 
 ## Contributors
 
+*Brian Missao da Vera
+
 Special thanks to
 
 * Marlon Brandão de Sousa - Brazilian Portuguese translation

--- a/addon/doc/es/README.tpl.md
+++ b/addon/doc/es/README.tpl.md
@@ -132,3 +132,4 @@ Agradecimientos especiales a
 * Tarik Hadžirović - Traducción Croata
 * Rémy Ruiz - Traducción Francés
 * Rémy Ruiz - Traducción Español
+* Brian Missao da Vera - Compatibilidad con NVDA 2022.1

--- a/addon/doc/fr/README.tpl.md
+++ b/addon/doc/fr/README.tpl.md
@@ -132,3 +132,4 @@ Remerciement spécial à
 * Tarik Hadžirović - Traduction Croate
 * Rémy Ruiz - Traduction Français
 * Rémy Ruiz - Traduction Espagnol
+* Brian Missao da Vera - Compatibilité NVDA 2022.1

--- a/addon/doc/hr/readme.tpl.md
+++ b/addon/doc/hr/readme.tpl.md
@@ -129,3 +129,4 @@ Posebno zahvaljujemo
 * Tarik Hadžirović - hrvatski prijevod
 * Rémy Ruiz - francuski prijevod
 * Rémy Ruiz - španjolski prijevod
+* Brian Missao da Vera - NVDA 2022.1 kompatibilnost

--- a/addon/doc/pt_BR/README.tpl.md
+++ b/addon/doc/pt_BR/README.tpl.md
@@ -8,7 +8,7 @@ Baixe o [complemento Timer e cronômetro simples para NVDA ${addon_version}](${a
 
 ## Timers e cronômetros
 
-Um timer inicia uma contagem regressiva a partir de um tempo inicial eterminado.
+Um timer inicia uma contagem regressiva a partir de um tempo inicial determinado.
 
 Um cronômetro inicia uma contagem a partir do 0 e continua até que seja instruído a parar. Quando isso acontece, o tempo total é exibido.
 
@@ -132,3 +132,4 @@ Agradecimentos a:
 * Tarik Hadžirović - Tradução para Croata
 * Rémy Ruiz - Tradução para Francês
 * Rémy Ruiz - Tradução para Espanhol
+* Brian Missao da Vera - Compatibilidade com NVDA 2022.1

--- a/addon/doc/pt_PT/README.tpl.md
+++ b/addon/doc/pt_PT/README.tpl.md
@@ -8,7 +8,7 @@ Baixe o [extra temporizador e cronómetro simples para NVDA ${addon_version}](${
 
 ## Temporizadores e cronómetros
 
-Um temporizador inicia uma contagem regressiva a partir de um tempo inicial eterminado.
+Um temporizador inicia uma contagem regressiva a partir de um tempo inicial determinado.
 
 Um cronómetro inicia uma contagem a partir do 0 e continua até que seja instruído a parar. Quando isso acontece, o tempo total é mostrado.
 
@@ -132,3 +132,4 @@ Agradecimentos a:
 * Tarik Hadžirović - Tradução para Croata
 * Rémy Ruiz - Tradução para Francês
 * Rémy Ruiz - Tradução para Espanhol
+* Brian Missao da Vera - Compatibilidade com NVDA 2022.1

--- a/buildVars.py
+++ b/buildVars.py
@@ -33,9 +33,9 @@ Control timer and stopwatch from anywhere using NVDA commands."""),
     # Documentation file name
     "addon_docFileName": "readme.html",
     # Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
-    "addon_minimumNVDAVersion": "2019.3.0",
+    "addon_minimumNVDAVersion": "2022.1",
     # Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-    "addon_lastTestedNVDAVersion": "2021.3.1",
+    "addon_lastTestedNVDAVersion": "2022.1",
     # Add-on update channel (default is None, denoting stable releases, and for development releases, use "dev"; do not change unless you know what you are doing)
     "addon_updateChannel": None,
 }

--- a/buildVars.py
+++ b/buildVars.py
@@ -25,7 +25,7 @@ Choose between speech, sound or no reporters.
 Monitor progress through reporters, settings dialog or anywhere using NVDA commands.
 Control timer and stopwatch from anywhere using NVDA commands."""),
     # version
-    "addon_version": "1.4.0",
+    "addon_version": "1.5.0",
     # Author(s)
     "addon_author": u"Marlon Brandão de Sousa <marlon.bsousa@gmail.com>",
     # URL for the add-on documentation support


### PR DESCRIPTION
This PR aims to make the timer for NVDA compatible with NVDA 2022.1.
There were changes to the plugins API in this NVDA update, which created the need to check if the timer used any of them.
No changes were found that impacted the code of Timer for NVDA, so it was only necessary to update the minimum supported version of the add-on in the manifest and insert credits in the translations.